### PR TITLE
Remove "event" Property

### DIFF
--- a/src/react-mailto.js
+++ b/src/react-mailto.js
@@ -56,9 +56,6 @@ export default class Mailto extends Component {
     };
 
     static displayName = 'Mailto';
-    static defaultProps = {
-        event: 'click'
-    };
 
     render() {
         const {to, cc, bcc, subject, body, secure, children, ...props} = this.props;


### PR DESCRIPTION
The unknown DOM property "event" was being added to the anchor tag. This causes an annoying error in React 16. I removed the property, as I didn't see any functionality it served (the storybook components work fine without it.)

Let me know if I'm mistaken about it not serving any useful functionality.